### PR TITLE
chore!: upgrade @sentry/types to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ]
   },
   "dependencies": {
-    "@sentry/types": "^6.15.0",
+    "@sentry/types": "^7.0.0",
     "roarr": "^7.8.0"
   },
   "description": "Sentry integration that adds Roarr logs to Sentry breadcrumbs.",

--- a/src/factories/createRoarrSentryIntegration.ts
+++ b/src/factories/createRoarrSentryIntegration.ts
@@ -1,10 +1,8 @@
-import {
-  Severity,
-} from '@sentry/types';
 import type {
   EventProcessor,
   Hub,
   Integration,
+  SeverityLevel,
 } from '@sentry/types';
 import type {
   LogLevelName,
@@ -14,19 +12,19 @@ import {
   getLogLevelName,
 } from 'roarr';
 
-const getSeverity = (logLevelName: LogLevelName) => {
+const getSeverity = (logLevelName: LogLevelName): SeverityLevel => {
   switch (logLevelName) {
     case 'trace':
     case 'debug':
-      return Severity.Debug;
+      return 'debug';
     case 'info':
-      return Severity.Info;
+      return 'info';
     case 'warn':
-      return Severity.Warning;
+      return 'warning';
     case 'error':
-      return Severity.Error;
+      return 'error';
     default:
-      return Severity.Error;
+      return 'error';
   }
 };
 


### PR DESCRIPTION
`Severity` enum was deprecated  in favour of a `SeverityLevel` string type. More details here: https://github.com/getsentry/sentry-javascript/releases/tag/7.0.0. 